### PR TITLE
Add strict compiler options for c++ compiler and nvcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,34 @@ add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
 # Set C++ standard to C++17 or later
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Set strict compilation flags for C++ compilers
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # Strict flags for GCC and Clang
+    add_compile_options(
+        -Wall          # Enable all warnings
+        -Wextra        # Enable extra warnings
+        -Wno-unknown-pragmas # Disable unroll warnings
+        -O3
+        # -Wpedantic     # Enforce strict compliance with standards. Comment to remove unwanted  warning: style of line directive is a GCC extension when using clang
+    )
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    # Strict flags for MSVC
+    add_compile_options(
+        /W4            # Enable high-level warnings
+        /WX            # Treat all warnings as errors
+    )
+endif()
+
+# CUDA-specific strict flags (only if CUDA is found)
+if (CMAKE_CUDA_COMPILER)
+    # Standard warnings and error flags
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=-Wall,-Wextra")
+
+    # Optional: suppress specific CUDA warnings if needed
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcudafe \"--diag_suppress=unsigned_compare_with_zero\"")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xptxas -O3")
+endif()
 
 # Include the FetchContent module
 include(FetchContent)

--- a/README.md
+++ b/README.md
@@ -22,32 +22,53 @@ To install cmake from cuda environment:
     ```bash
     conda install cmake
     ```
-5. Install a C++14 (or higher) compatible compiler. It must be compatible with the installed CUDA version (some [compatibilities](https://gist.github.com/ax3l/9489132)).
-    1. In Ubuntu you can install `build-essential` package<br>
-    If a specific version of g++ and gcc is needed, follow this instructions for a Linux based system (from [stackoverflow](https://askubuntu.com/questions/26498/how-to-choose-the-default-gcc-and-g-version)).
-    ```sh
-    # First remove update-alternatives for gcc and g++
-    sudo update-alternatives --remove-all gcc 
-    sudo update-alternatives --remove-all g++
-    # Install required gcc and g++ packages (e.g. gcc and g++ 11)
-    sudo apt-get install gcc-11 g++-11
-    # Install alternatives
-    # sudo update-alternatives --install <link> <name> <path> <priority>
-    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 10
+   5. Install a C++14 (or higher) compatible compiler. It must be compatible with the installed CUDA version (some [compatibilities](https://gist.github.com/ax3l/9489132)).
+       1. On Ubuntu you can install `build-essential` package<br>
+       If a specific version of g++ and gcc is needed, follow these instructions for a Linux based system (from [stackoverflow](https://askubuntu.com/questions/26498/how-to-choose-the-default-gcc-and-g-version)).
+       ```sh
+       # First remove update-alternatives for gcc and g++
+       sudo update-alternatives --remove-all gcc 
+       sudo update-alternatives --remove-all g++
+       # Install required gcc and g++ packages (e.g. gcc and g++ 11)
+       sudo apt-get install gcc-11 g++-11
+       # Install alternatives
+       # sudo update-alternatives --install <link> <name> <path> <priority>
+       sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 10
 
-    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 10
+       sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 10
 
-    sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30
-    sudo update-alternatives --set cc /usr/bin/gcc
+       sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30
+       sudo update-alternatives --set cc /usr/bin/gcc
 
-    sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30
-    sudo update-alternatives --set c++ /usr/bin/g++
+       sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30
+       sudo update-alternatives --set c++ /usr/bin/g++
 
-    # If multiple alternatives are installed, configuration of the default commands for gcc and g++ can be done interactively
-    sudo update-alternatives --config gcc
-    sudo update-alternatives --config g++
-    ```
-    2. In Windows you need to install Visual Studio version that is compatible with CUDA 11.7
+       # If multiple alternatives are installed, configuration of the default commands for gcc and g++ can be done interactively
+       sudo update-alternatives --config gcc
+       sudo update-alternatives --config g++
+       ```
+      Notes: The NVCC host compiler can be either Clang or GCC at their latest versions. Clang-18 and GCC-13 have been tested on Ubuntu 24.
+      On Linux, NVCC uses `cc` and `c++` as host compilers.<br><br>
+   
+      When using the C++ standard library (libstdc++), the only supported implementation is from GCC: `gcc` and `g++` must link to a compatible version of the Cuda toolkit. For `spconv`, these are `gcc-11` and `g++-11` respectively.
+      As above on Linux, use `update-alternatives` to set up the compiler of your choice. For example to use `clang-18`:
+       ```sh
+      # Install clang-18 and clang++-18 packages
+       sudo apt-get install clang-18 clang++-18 
+   
+      # Install alternatives
+       # sudo update-alternatives --install <link> <name> <path> <priority>
+       sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-18 20
+       sudo update-alternatives --set cc /usr/bin/clang-18
+
+       sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-18 20
+       sudo update-alternatives --set c++ /usr/bin/clang++-18
+
+       # If multiple alternatives are installed, configuration of the default commands for gcc and g++ can be done interactively
+       
+       sudo update-alternatives --config c++
+       ```
+       2. On Windows you need to install Visual Studio version that is compatible with CUDA 11.7. Clang and GCC compilers ar not supported on Windows.
 6. Activate the `spconv` environment: `conda activate spconv`
 7. After having activated the `spconv` environment, if building the package in Ubuntu, you have to modify the environment variables `PATH` and `CPATH`, and set the `CUDA_PATH` and `CUDA_HOME` the nvcc-compiler, the cuda headers and libraries in the Conda environment's paths are found. 
 

--- a/include/spconv/geometry.h
+++ b/include/spconv/geometry.h
@@ -38,7 +38,7 @@ namespace spconv
     Index m, offset;
     bool valid = false;
 #pragma unroll
-    for (int i = 0; i < NDim; ++i)
+    for (size_t i = 0; i < NDim; ++i)
     {
       lowers[i] = (input_pos[i] - (kernelSize[i] - 1) * dilation[i] - 1 +
                    stride[i] + padding[i]) /
@@ -54,7 +54,7 @@ namespace spconv
     }
 
 #pragma unroll
-    for (int i = 0; i < NDim; ++i)
+    for (size_t i = 0; i < NDim; ++i)
     {
       counter[i] = 0;
     }
@@ -110,7 +110,7 @@ namespace spconv
     Index m, offset;
     bool valid = false;
 #pragma unroll
-    for (int i = 0; i < NDim; ++i)
+    for (size_t i = 0; i < NDim; ++i)
     {
       lowers[i] = input_pos[i] * stride[i] - padding[i];
       uppers[i] = lowers[i] + (kernelSize[i] - 1) * dilation[i];
@@ -122,7 +122,7 @@ namespace spconv
       numPoints *= counterSize[i];
     }
 #pragma unroll
-    for (int i = 0; i < NDim; ++i)
+    for (size_t i = 0; i < NDim; ++i)
     {
       counter[i] = 0;
     }
@@ -177,13 +177,13 @@ namespace spconv
     Index batchIdx = 0;
     Index spatialVolume = 1;
 #pragma unroll
-    for (int i = 0; i < NDim; ++i)
+    for (size_t i = 0; i < NDim; ++i)
     {
       spatialVolume *= outSpatialShape[i];
     }
     Index kernelVolume = 1;
 #pragma unroll
-    for (int i = 0; i < NDim; ++i)
+    for (size_t i = 0; i < NDim; ++i)
     {
       kernelVolume *= kernelSize[i];
     }
@@ -243,13 +243,13 @@ namespace spconv
     Index batchIdx = 0;
     Index spatialVolume = 1;
 #pragma unroll
-    for (int i = 0; i < NDim; ++i)
+    for (size_t i = 0; i < NDim; ++i)
     {
       spatialVolume *= outSpatialShape[i];
     }
     Index kernelVolume = 1;
 #pragma unroll
-    for (int i = 0; i < NDim; ++i)
+    for (size_t i = 0; i < NDim; ++i)
     {
       kernelVolume *= kernelSize[i];
     }
@@ -303,18 +303,16 @@ namespace spconv
                            const Index *const stride, const Index *const padding,
                            const Index *dilation, const Index *const outSpatialShape)
   {
-    Index numAct = 0;
     auto numActIn = indicesIn.dim(0);
-    Index batchIdx = 0;
     Index spatialVolume = 1;
 #pragma unroll
-    for (int i = 0; i < NDim; ++i)
+    for (size_t i = 0; i < NDim; ++i)
     {
       spatialVolume *= outSpatialShape[i];
     }
     Index kernelVolume = 1;
 #pragma unroll
-    for (int i = 0; i < NDim; ++i)
+    for (size_t i = 0; i < NDim; ++i)
     {
       kernelVolume *= kernelSize[i];
     }

--- a/include/spconv/indice.h
+++ b/include/spconv/indice.h
@@ -24,7 +24,7 @@ namespace spconv
         struct CreateConvIndicePairFunctorP1
         {
             Index operator()(
-                const Device &d, tv::TensorView<const Index> indicesIn,
+                tv::TensorView<const Index> indicesIn,
                 tv::TensorView<Index> indicesOut, tv::TensorView<IndexGrid> gridsOut,
                 tv::TensorView<Index> indicePairs, tv::TensorView<Index> indiceNum,
                 tv::TensorView<Index> indicePairUnique,
@@ -35,15 +35,52 @@ namespace spconv
                 const tv::SimpleVector<Index, NDim> outSpatialShape, bool transpose);
         };
 
+        // Specialization for GPU
+        template <typename Index, typename IndexGrid, unsigned NDim>
+        struct CreateConvIndicePairFunctorP1<tv::GPU, Index, IndexGrid, NDim>
+        {
+            Index operator()(
+                const tv::GPU &d,  // Specific to GPU
+                tv::TensorView<const Index> indicesIn,
+                tv::TensorView<Index> indicesOut,
+                tv::TensorView<IndexGrid> gridsOut,
+                tv::TensorView<Index> indicePairs,
+                tv::TensorView<Index> indiceNum,
+                tv::TensorView<Index> indicePairUnique,
+                const tv::SimpleVector<Index, NDim> kernelSize,
+                const tv::SimpleVector<Index, NDim> stride,
+                const tv::SimpleVector<Index, NDim> padding,
+                const tv::SimpleVector<Index, NDim> dilation,
+                const tv::SimpleVector<Index, NDim> outSpatialShape,
+                bool transpose);
+        };
+
         template <typename Device, typename Index, typename IndexGrid, unsigned NDim>
         struct CreateConvIndicePairFunctorP2
         {
             Index operator()(
-                const Device &d, tv::TensorView<const Index> indicesIn,
-                tv::TensorView<Index> indicesOut, tv::TensorView<IndexGrid> gridsOut,
-                tv::TensorView<Index> indicePairs, tv::TensorView<Index> indiceNum,
+                tv::TensorView<const Index> indicesIn,
+                tv::TensorView<Index> indicesOut,
+                tv::TensorView<IndexGrid> gridsOut,
+                tv::TensorView<Index> indicePairs,
+                tv::TensorView<Index> indiceNum,
                 tv::TensorView<Index> indicePairUnique,
-                const tv::SimpleVector<Index, NDim> outSpatialShape, bool transpose,
+                const tv::SimpleVector<Index, NDim> outSpatialShape,
+                bool transpose,
+                bool resetGrid = false);
+        };
+        // Specialization for GPU
+        template <typename Index, typename IndexGrid, unsigned NDim>
+        struct CreateConvIndicePairFunctorP2<tv::GPU, Index, IndexGrid, NDim>
+        {
+            Index operator()(
+                const tv::GPU &d,
+                tv::TensorView<const Index> indicesIn,
+                tv::TensorView<Index> indicesOut,
+                tv::TensorView<IndexGrid> gridsOut,
+                tv::TensorView<Index> indicePairs,
+                tv::TensorView<Index> indicePairUnique,
+                const tv::SimpleVector<Index, NDim> outSpatialShape,
                 bool resetGrid = false);
         };
 
@@ -51,27 +88,59 @@ namespace spconv
         struct CreateConvIndicePairFunctor
         {
             Index operator()(
-                const Device &d, tv::TensorView<const Index> indicesIn,
+                tv::TensorView<const Index> indicesIn,
                 tv::TensorView<Index> indicesOut, tv::TensorView<IndexGrid> gridsOut,
                 tv::TensorView<Index> indicePairs, tv::TensorView<Index> indiceNum,
                 const tv::SimpleVector<Index, NDim> kernelSize,
                 const tv::SimpleVector<Index, NDim> stride,
                 const tv::SimpleVector<Index, NDim> padding,
                 const tv::SimpleVector<Index, NDim> dilation,
-                const tv::SimpleVector<Index, NDim> outSpatialShape, bool transpose, bool resetGrid = false);
+                const tv::SimpleVector<Index, NDim> outSpatialShape, bool transpose);
+        };
+
+        // GPU specialization
+        template <typename Index, typename IndexGrid, unsigned NDim>
+        struct CreateConvIndicePairFunctor<tv::GPU, Index, IndexGrid, NDim>
+        {
+            Index operator()(
+                const tv::GPU &d,
+                tv::TensorView<const Index> indicesIn,
+                tv::TensorView<Index> indicesOut, tv::TensorView<IndexGrid> gridsOut,
+                tv::TensorView<Index> indicePairs, tv::TensorView<Index> indiceNum,
+                const tv::SimpleVector<Index, NDim> kernelSize,
+                const tv::SimpleVector<Index, NDim> stride,
+                const tv::SimpleVector<Index, NDim> padding,
+                const tv::SimpleVector<Index, NDim> dilation,
+                const tv::SimpleVector<Index, NDim> outSpatialShape, bool transpose);
         };
 
         template <typename Device, typename Index, typename IndexGrid, unsigned NDim>
         struct CreateSubMIndicePairFunctor
         {
             Index operator()(
-                const Device &d, tv::TensorView<const Index> indicesIn, tv::TensorView<IndexGrid> gridsOut,
+                tv::TensorView<const Index> indicesIn, tv::TensorView<IndexGrid> gridsOut,
                 tv::TensorView<Index> indicePairs, tv::TensorView<Index> indiceNum,
                 const tv::SimpleVector<Index, NDim> kernelSize,
                 const tv::SimpleVector<Index, NDim> stride,
                 const tv::SimpleVector<Index, NDim> padding,
                 const tv::SimpleVector<Index, NDim> dilation,
-                const tv::SimpleVector<Index, NDim> outSpatialShape, bool transpose, bool resetGrid = false);
+                const tv::SimpleVector<Index, NDim> outSpatialShape);
+        };
+
+        // GPU specialization
+        template <typename Index, typename IndexGrid, unsigned NDim>
+        struct CreateSubMIndicePairFunctor<tv::GPU, Index, IndexGrid, NDim> {
+            Index operator()(const tv::GPU &d,  // Added device parameter for GPU specialization
+                             tv::TensorView<const Index> indicesIn,
+                             tv::TensorView<IndexGrid> gridsOut,
+                             tv::TensorView<Index> indicePairs,
+                             tv::TensorView<Index> indiceNum,
+                             const tv::SimpleVector<Index, NDim> kernelSize,
+                             const tv::SimpleVector<Index, NDim> stride,
+                             const tv::SimpleVector<Index, NDim> padding,
+                             const tv::SimpleVector<Index, NDim> dilation,
+                             const tv::SimpleVector<Index, NDim> outSpatialShape,
+                             bool resetGrid);
         };
     } // namespace functor
 } // namespace spconv

--- a/include/spconv/maxpool.h
+++ b/include/spconv/maxpool.h
@@ -15,23 +15,55 @@
 #ifndef SPARSE_MAXPOOL_FUNCTOR_H_
 #define SPARSE_MAXPOOL_FUNCTOR_H_
 #include <tensorview/tensorview.h>
+#include <ATen/ATen.h>
+#include <spconv/mp_helper.h>
 
 namespace spconv
 {
     namespace functor
     {
+        // General template declaration for SparseMaxPoolForwardFunctor
         template <typename Device, typename T, typename Index>
         struct SparseMaxPoolForwardFunctor
         {
-            void operator()(const Device &d, tv::TensorView<T> outFeatures,
+            void operator()(tv::TensorView<T> outFeatures,
                             tv::TensorView<const T> inFeatures,
                             tv::TensorView<const Index> indices, int size);
         };
 
+        // Specialization for GPU device
+        template <typename T, typename Index>
+        struct SparseMaxPoolForwardFunctor<tv::GPU, T, Index>
+        {
+            using vecload_type_t =
+                std::conditional_t<std::is_same<T, at::Half>::value, int2, int4>;
+            using kernel_block_t = mp_list_c<int, 64, 32, 16>;
+            void operator()(const tv::GPU &d,
+                            tv::TensorView<T> outFeatures,
+                            tv::TensorView<const T> inFeatures,
+                            tv::TensorView<const Index> indices, int size);
+        };
+
+        // General template declaration for SparseMaxPoolBackwardFunctor
         template <typename Device, typename T, typename Index>
         struct SparseMaxPoolBackwardFunctor
         {
-            void operator()(const Device &d, tv::TensorView<const T> outFeatures,
+            void operator()(tv::TensorView<const T> outFeatures,
+                            tv::TensorView<const T> inFeatures,
+                            tv::TensorView<const T> dout,
+                            tv::TensorView<T> din,
+                            tv::TensorView<const Index> indices, int size);
+        };
+
+        // Specialization for GPU device
+        template <typename T, typename Index>
+        struct SparseMaxPoolBackwardFunctor<tv::GPU, T, Index>
+        {
+            using vecload_type_t =
+                std::conditional_t<std::is_same<T, at::Half>::value, int2, int4>;
+            using kernel_block_t = mp_list_c<int, 64, 32, 16>;
+            void operator()(const tv::GPU &d,
+                            tv::TensorView<const T> outFeatures,
                             tv::TensorView<const T> inFeatures,
                             tv::TensorView<const T> dout,
                             tv::TensorView<T> din,

--- a/include/tensorview/tensorview.h
+++ b/include/tensorview/tensorview.h
@@ -198,7 +198,7 @@ public:
     typedef std::forward_iterator_tag iterator_category;
     typedef std::ptrdiff_t difference_type;
     TV_HOST_DEVICE_INLINE iterator(pointer ptr) : ptr_(ptr) {}
-    TV_HOST_DEVICE_INLINE self_type operator++(int junk) {
+    TV_HOST_DEVICE_INLINE self_type operator++(int) {
       self_type i = *this;
       ptr_++;
       return i;
@@ -229,7 +229,7 @@ public:
     typedef std::ptrdiff_t difference_type;
     typedef std::forward_iterator_tag iterator_category;
     TV_HOST_DEVICE_INLINE const_iterator(pointer ptr) : ptr_(ptr) {}
-    TV_HOST_DEVICE_INLINE self_type operator++(int junk) {
+    TV_HOST_DEVICE_INLINE self_type operator++(int) {
       self_type i = *this;
       ptr_++;
       return i;
@@ -368,7 +368,7 @@ struct ShapeBase : public SimpleVector<int, MaxDim> {
     TV_ASSERT(start >= 0 && start <= this->mSize);
 #endif
     ShapeBase<MaxDim> shape;
-    for (int i = start; i < this->mSize; ++i) {
+    for (size_t i = start; i < this->mSize; ++i) {
       shape.push_back(this->mArray[i]);
     }
     return shape;
@@ -492,26 +492,26 @@ template <int N> struct ArrayIndexRowMajor {
 };
 
 template <> struct ArrayIndexRowMajor<0> {
-  TV_HOST_DEVICE_INLINE static unsigned run(const Shape &shape,
-                                            const Shape &indexes) {
+  TV_HOST_DEVICE_INLINE static unsigned run(const Shape&,
+                                            const Shape&) {
     return 0;
   }
 };
 
 namespace detail {
 template <typename T> constexpr const char *simpleTypeName(T val = T());
-template <> constexpr const char *simpleTypeName(float val) {
+template <> constexpr const char *simpleTypeName(float) {
   return "float32";
 }
-template <> constexpr const char *simpleTypeName(double val) {
+template <> constexpr const char *simpleTypeName(double) {
   return "float64";
 }
-template <> constexpr const char *simpleTypeName(int val) { return "int32"; }
-template <> constexpr const char *simpleTypeName(unsigned val) {
+template <> constexpr const char *simpleTypeName(int) { return "int32"; }
+template <> constexpr const char *simpleTypeName(unsigned) {
   return "uint32";
 }
-template <> constexpr const char *simpleTypeName(long val) { return "int64"; }
-template <> constexpr const char *simpleTypeName(unsigned long val) {
+template <> constexpr const char *simpleTypeName(long) { return "int64"; }
+template <> constexpr const char *simpleTypeName(unsigned long) {
   return "uint64";
 }
 }; // namespace detail
@@ -1068,16 +1068,16 @@ Os &operator<<(Os &os, const TensorView<const T, Rank> &dt) {
 
 namespace detail {
 template <typename T> constexpr const char *printfTypeFormat(T val = T());
-template <> constexpr const char *printfTypeFormat(float val) { return "%.2f"; }
-template <> constexpr const char *printfTypeFormat(double val) {
+template <> constexpr const char *printfTypeFormat(float) { return "%.2f"; }
+template <> constexpr const char *printfTypeFormat(double) {
   return "%.2f";
 }
-template <> constexpr const char *printfTypeFormat(int val) { return "%d"; }
-template <> constexpr const char *printfTypeFormat(unsigned val) {
+template <> constexpr const char *printfTypeFormat(int) { return "%d"; }
+template <> constexpr const char *printfTypeFormat(unsigned) {
   return "%u";
 }
-template <> constexpr const char *printfTypeFormat(long val) { return "%ld"; }
-template <> constexpr const char *printfTypeFormat(unsigned long val) {
+template <> constexpr const char *printfTypeFormat(long) { return "%ld"; }
+template <> constexpr const char *printfTypeFormat(unsigned long) {
   return "%lu";
 }
 }; // namespace detail
@@ -1094,7 +1094,7 @@ TV_HOST_DEVICE void printTensorView(const TensorView<T> tensor,
   }
   Shape counter = tensor.shape();
   auto tensor_flat = tensor.view(-1);
-  for (int i = 0; i < counter.ndim(); ++i) {
+  for (size_t i = 0; i < counter.ndim(); ++i) {
     counter[i] = 0;
     printf("[");
   }

--- a/include/torch_utils.h
+++ b/include/torch_utils.h
@@ -27,7 +27,7 @@ struct TorchGPU: public tv::GPU {
 };
 
 template <typename T> void check_torch_dtype(const torch::Tensor &tensor) {
-  switch (tensor.type().scalarType()) {
+  switch (tensor.scalar_type()) {
   case at::ScalarType::Double: {
     auto val = std::is_same<std::remove_const_t<T>, double>::value;
     TV_ASSERT_RT_ERR(val, "error");
@@ -61,6 +61,6 @@ tv::TensorView<T> torch2tv(const torch::Tensor &tensor) {
   for (auto i : tensor.sizes()) {
     shape.push_back(i);
   }
-  return tv::TensorView<T>(tensor.data<std::remove_const_t<T>>(), shape);
+  return tv::TensorView<T>(tensor.data_ptr<std::remove_const_t<T>>(), shape);
 }
 } // namespace tv

--- a/spconv/conv.py
+++ b/spconv/conv.py
@@ -147,8 +147,8 @@ class SparseConvolution(SparseModule):
                 outids, _, indice_pairs, indice_pair_num, _ = datas
             else:
                 outids, indice_pairs, indice_pair_num = ops.get_indice_pairs(
-                    indices, batch_size, spatial_shape, self.kernel_size,
-                    self.stride, self.padding, self.dilation, self.output_padding, self.subm, self.transposed, grid=input.grid)
+                    indices=indices, batch_size=batch_size, spatial_shape=spatial_shape, ksize=self.kernel_size,
+                    stride=self.stride, padding=self.padding, dilation=self.dilation, out_padding=self.output_padding, subm=self.subm, transpose=self.transposed, grid=input.grid)
                 input.indice_dict[self.indice_key] = (outids, indices, indice_pairs, indice_pair_num, spatial_shape)
         if self.subm:
             out_features = Fsp.indice_subm_conv(features, self.weight,

--- a/spconv/ops.py
+++ b/spconv/ops.py
@@ -85,7 +85,7 @@ def get_indice_pairs(indices,
             get_indice_pairs_func = torch.ops.spconv.get_indice_pairs_3d
         else:
             raise NotImplementedError
-        return get_indice_pairs_func(indices, batch_size, out_shape, spatial_shape, ksize,
+        return get_indice_pairs_func(indices, batch_size, out_shape, ksize,
                             stride, padding, dilation, out_padding, int(subm), int(transpose))
     else:
         if ndim == 2:
@@ -94,7 +94,7 @@ def get_indice_pairs(indices,
             get_indice_pairs_func = torch.ops.spconv.get_indice_pairs_grid_3d
         else:
             raise NotImplementedError
-        return get_indice_pairs_func(indices, grid, batch_size, out_shape, spatial_shape, ksize,
+        return get_indice_pairs_func(indices, grid, batch_size, out_shape, ksize,
                             stride, padding, dilation, out_padding, int(subm), int(transpose))
 
 

--- a/src/spconv/indice.cc
+++ b/src/spconv/indice.cc
@@ -14,7 +14,7 @@
 
 #include <spconv/geometry.h>
 #include <spconv/indice.h>
-#include <spconv/spconv_ops.h>
+
 #include <torch/script.h>
 
 namespace spconv
@@ -22,10 +22,8 @@ namespace spconv
 
   namespace functor
   {
-    template <typename Index, typename IndexGrid, unsigned NDim>
-    struct CreateConvIndicePairFunctor<tv::CPU, Index, IndexGrid, NDim>
-    {
-      Index operator()(const tv::CPU &d, tv::TensorView<const Index> indicesIn,
+    template <typename Device, typename Index, typename IndexGrid, unsigned NDim>
+      Index CreateConvIndicePairFunctor<Device, Index, IndexGrid, NDim>::operator()(tv::TensorView<const Index> indicesIn,
                        tv::TensorView<Index> indicesOut,
                        tv::TensorView<IndexGrid> gridsOut,
                        tv::TensorView<Index> indicePairs,
@@ -35,26 +33,16 @@ namespace spconv
                        const tv::SimpleVector<Index, NDim> padding,
                        const tv::SimpleVector<Index, NDim> dilation,
                        const tv::SimpleVector<Index, NDim> outSpatialShape,
-                       bool transpose, bool resetGrid)
-      {
+                       bool transpose) {
         if (transpose)
-          return getIndicePairsDeConv<Index, IndexGrid, NDim>(
-              indicesIn, indicesOut,
-              gridsOut, indicePairs, indiceNum,
-              kernelSize.data(), stride.data(), padding.data(), dilation.data(),
-              outSpatialShape.data());
+            return getIndicePairsDeConv<Index, IndexGrid, NDim>(indicesIn, indicesOut, gridsOut, indicePairs, indiceNum, kernelSize.data(), stride.data(), padding.data(),
+                                                                dilation.data(), outSpatialShape.data());
         else
-          return getIndicePairsConv<Index, IndexGrid, NDim>(
-              indicesIn, indicesOut,
-              gridsOut, indicePairs, indiceNum,
-              kernelSize.data(), stride.data(), padding.data(), dilation.data(),
-              outSpatialShape.data());
-      }
-    };
-    template <typename Index, typename IndexGrid, unsigned NDim>
-    struct CreateSubMIndicePairFunctor<tv::CPU, Index, IndexGrid, NDim>
-    {
-      Index operator()(const tv::CPU &d, tv::TensorView<const Index> indicesIn,
+            return getIndicePairsConv<Index, IndexGrid, NDim>(indicesIn, indicesOut, gridsOut, indicePairs, indiceNum, kernelSize.data(), stride.data(), padding.data(),
+                                                              dilation.data(), outSpatialShape.data());
+    }
+    template <typename Device, typename Index, typename IndexGrid, unsigned NDim>
+      Index CreateSubMIndicePairFunctor<Device, Index, IndexGrid, NDim>::operator()(tv::TensorView<const Index> indicesIn,
                        tv::TensorView<IndexGrid> gridsOut,
                        tv::TensorView<Index> indicePairs,
                        tv::TensorView<Index> indiceNum,
@@ -62,15 +50,10 @@ namespace spconv
                        const tv::SimpleVector<Index, NDim> stride,
                        const tv::SimpleVector<Index, NDim> padding,
                        const tv::SimpleVector<Index, NDim> dilation,
-                       const tv::SimpleVector<Index, NDim> outSpatialShape,
-                       bool transpose, bool resetGrid)
-      {
-        return getIndicePairsSubM<Index, IndexGrid, NDim>(
-            indicesIn,
-            gridsOut, indicePairs, indiceNum,
-            kernelSize.data(), stride.data(), padding.data(), dilation.data(), outSpatialShape.data());
-      }
-    };
+                       const tv::SimpleVector<Index, NDim> outSpatialShape) {
+        return getIndicePairsSubM<Index, IndexGrid, NDim>(indicesIn, gridsOut, indicePairs, indiceNum, kernelSize.data(), stride.data(), padding.data(), dilation.data(),
+                                                          outSpatialShape.data());
+    }
   } // namespace functor
 
 #define DECLARE_CPU_SPECS_INDEX_NDIM(Index, NDIM)                                  \

--- a/src/spconv/maxpool.cc
+++ b/src/spconv/maxpool.cc
@@ -20,38 +20,29 @@ namespace spconv
 
   namespace functor
   {
-    template <typename T, typename Index>
-    struct SparseMaxPoolForwardFunctor<tv::CPU, T, Index>
-    {
-      void operator()(const tv::CPU &d, tv::TensorView<T> outFeatures,
+    template <typename Device, typename T, typename Index>
+      void SparseMaxPoolForwardFunctor<Device, T, Index>::operator()(tv::TensorView<T> outFeatures,
                       tv::TensorView<const T> inFeatures,
-                      tv::TensorView<const Index> indices, int size)
-      {
+                      tv::TensorView<const Index> indices, int size) {
         int stride = outFeatures.dim(1);
         auto outFeaturesData = outFeatures.data();
         auto inFeaturesData = inFeatures.data();
         auto indicesIn = indices.subview(0).data();
         auto indicesOut = indices.subview(1).data();
         Index idxi, idxo;
-        for (int row = 0; row < size; row++)
-        {
-          idxi = indicesIn[row] * stride;
-          idxo = indicesOut[row] * stride;
-          for (int plane = 0; plane < stride; ++plane)
-            if (outFeaturesData[idxo + plane] < inFeaturesData[idxi + plane])
-              outFeaturesData[idxo + plane] = inFeaturesData[idxi + plane];
+        for (int row = 0; row < size; row++) {
+            idxi = indicesIn[row] * stride;
+            idxo = indicesOut[row] * stride;
+            for (int plane = 0; plane < stride; ++plane)
+                if (outFeaturesData[idxo + plane] < inFeaturesData[idxi + plane]) outFeaturesData[idxo + plane] = inFeaturesData[idxi + plane];
         }
-      }
-    };
+    }
 
-    template <typename T, typename Index>
-    struct SparseMaxPoolBackwardFunctor<tv::CPU, T, Index>
-    {
-      void operator()(const tv::CPU &d, tv::TensorView<const T> outFeatures,
+    template <typename Device, typename T, typename Index>
+      void SparseMaxPoolBackwardFunctor<Device, T, Index>::operator()(tv::TensorView<const T> outFeatures,
                       tv::TensorView<const T> inFeatures,
                       tv::TensorView<const T> dout, tv::TensorView<T> din,
-                      tv::TensorView<const Index> indices, int size)
-      {
+                      tv::TensorView<const Index> indices, int size) {
         int stride = outFeatures.dim(1);
         auto outFeaturesData = outFeatures.data();
         auto inFeaturesData = inFeatures.data();
@@ -60,16 +51,13 @@ namespace spconv
         auto indicesIn = indices.subview(0).data();
         auto indicesOut = indices.subview(1).data();
         Index idxi, idxo;
-        for (int row = 0; row < size; row++)
-        {
-          idxi = indicesIn[row] * stride;
-          idxo = indicesOut[row] * stride;
-          for (int plane = 0; plane < stride; ++plane)
-            if (outFeaturesData[idxo + plane] == inFeaturesData[idxi + plane])
-              dinData[idxi + plane] += doutData[idxo + plane];
+        for (int row = 0; row < size; row++) {
+            idxi = indicesIn[row] * stride;
+            idxo = indicesOut[row] * stride;
+            for (int plane = 0; plane < stride; ++plane)
+                if (outFeaturesData[idxo + plane] == inFeaturesData[idxi + plane]) dinData[idxi + plane] += doutData[idxo + plane];
         }
-      }
-    };
+    }
   } // namespace functor
 
 #define DECLARE_CPU_SPECS_T_INDEX(T, Index)                                \

--- a/src/spconv/reordering.cc
+++ b/src/spconv/reordering.cc
@@ -19,43 +19,30 @@ namespace spconv
 {
   namespace functor
   {
-    template <typename T, typename Index>
-    struct SparseGatherFunctor<tv::CPU, T, Index>
-    {
-      void operator()(const tv::CPU &d, tv::TensorView<T> buffer, tv::TensorView<const T> features,
-                      tv::TensorView<const Index> indices, int size)
-      {
+    template <typename Device, typename T, typename Index>
+      void SparseGatherFunctor<Device, T, Index>::operator()(tv::TensorView<T> buffer, tv::TensorView<const T> features,
+                      tv::TensorView<const Index> indices, int size) {
         int numPlanes = features.dim(1);
-        for (int i = 0; i < size; ++i)
-        {
-          std::memcpy(buffer.data() + i * numPlanes,
-                      features.data() + indices[i] * numPlanes,
-                      sizeof(T) * numPlanes);
+        for (int i = 0; i < size; ++i) {
+            std::memcpy(buffer.data() + i * numPlanes, features.data() + indices[i] * numPlanes, sizeof(T) * numPlanes);
         }
-      }
-    };
+    }
 
-    template <typename T, typename Index>
-    struct SparseScatterAddFunctor<tv::CPU, T, Index>
-    {
-      void operator()(const tv::CPU &d, tv::TensorView<T> outFeatures,
+    template <typename Device, typename T, typename Index>
+      void SparseScatterAddFunctor<Device, T, Index>::operator()(tv::TensorView<T> outFeatures,
                       tv::TensorView<const T> buffer, tv::TensorView<const Index> indices,
-                      int size, bool stable)
-      {
+                      int size) {
         int numPlanes = outFeatures.dim(1);
         const T *buf = buffer.data();
         T *out = outFeatures.data();
-        for (int i = 0; i < size; ++i)
-        {
-          buf = buffer.data() + i * numPlanes;
-          out = outFeatures.data() + indices[i] * numPlanes;
-          for (int j = 0; j < numPlanes; ++j)
-          {
-            out[j] += buf[j];
-          }
+        for (int i = 0; i < size; ++i) {
+            buf = buffer.data() + i * numPlanes;
+            out = outFeatures.data() + indices[i] * numPlanes;
+            for (int j = 0; j < numPlanes; ++j) {
+                out[j] += buf[j];
+            }
         }
-      }
-    };
+    }
 
   } // namespace functor
 


### PR DESCRIPTION
**Add Stricter Compiler Options for C++ Host and NVCC**

This update introduces stricter compiler flags for both the C++ host compiler and NVCC to enforce better code quality and standards compliance. The changes address additional warnings and errors, which will be corrected as part of this merge.